### PR TITLE
chore(ci): use node-version-file to setup node

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -36,14 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Read .nvmrc
-        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-        id: nvm
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version-file: '.nvmrc'
 
       - run: npm ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Read .nvmrc
-        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-        id: nvm
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version-file: '.nvmrc'
 
       - run: npm ci
 


### PR DESCRIPTION
The setup-node action now has built in support for [node version files](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file)!

Thanks for updating the action with node 16 😁 