### PR TITLE
feat: add github api token input

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -66,6 +66,7 @@ jobs:
         uses: ./
         with:
           terragrunt_version: latest
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate latest
         run: terragrunt --version

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
         uses: autero1/action-terragrunt@v1.1.0
         with:
           terragrunt_version: 0.21.13
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Interact with Terragrunt
         run: terragrunt --version
 ```
@@ -39,6 +40,7 @@ jobs:
 | Parameter | Description | Required |
 | --------- | ----------- | -------- |
 | `terragrunt_version` | Terragrunt [version](https://github.com/gruntwork-io/terragrunt/releases) to deploy. Use `latest` for the most recent version. | true |
+| `token` | Github API Token to avoid rate limiting while getting latest Terragrunt release | false |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   terragrunt_version:
     description: 'Terragrunt version to install'
     required: true
+  token:
+    description: 'Github token to use for getting latest release'
+    required: false
 outputs:
   terragrunt_path:
     description: 'Path to the terragrunt binary'

--- a/src/action.ts
+++ b/src/action.ts
@@ -33,7 +33,9 @@ export function getDownloadURL(version: string): string {
 }
 
 export const getLatestVersion = async (): Promise<string | null> => {
-  const octokit = new Octokit();
+  const octokit = new Octokit({
+    auth: getInputs().GithubToken
+  });
 
   const latestRelease = await octokit.repos.getLatestRelease({
     owner: 'gruntwork-io',

--- a/src/get-inputs-and-outputs.ts
+++ b/src/get-inputs-and-outputs.ts
@@ -10,8 +10,11 @@ export function getInputs(): Inputs {
   if (!tgVersion.startsWith('v') && tgVersion.toLowerCase() !== 'latest') {
     tgVersion = `v${tgVersion}`;
   }
+  const token = core.getInput('token') || undefined;
+
   const inps: Inputs = {
-    TerragruntVersion: tgVersion
+    TerragruntVersion: tgVersion,
+    GithubToken: token
   };
 
   showInputs(inps);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
 export interface Inputs {
   readonly TerragruntVersion: string;
+  readonly GithubToken?: string;
 }
 
 export interface Outputs {


### PR DESCRIPTION
Add a `token` input in order to pass
```
with:
  token: ${{ secrets.GITHUB_TOKEN }}
```
to have authenticated call when using `Octokit` and avoid rate limiting from Github

Fix #68 