### PR TITLE
fix: use tag instead of name for latestRelease

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -42,7 +42,7 @@ export const getLatestVersion = async (): Promise<string | null> => {
     repo: 'terragrunt'
   });
 
-  return latestRelease.data.tag;
+  return latestRelease.data.tag_name;
 };
 
 const walkSync = function (

--- a/src/action.ts
+++ b/src/action.ts
@@ -42,7 +42,7 @@ export const getLatestVersion = async (): Promise<string | null> => {
     repo: 'terragrunt'
   });
 
-  return latestRelease.data.name;
+  return latestRelease.data.tag;
 };
 
 const walkSync = function (


### PR DESCRIPTION
Using `name` will prevent the action from downloading the latestRelease as the name starts with a space.

![Screenshot 2023-05-05 at 14 27 45](https://user-images.githubusercontent.com/7438139/236461437-ed0673e8-72d6-4fc5-b584-567819c26cfe.png)

https://docs.github.com/en/graphql/reference/objects#release